### PR TITLE
Update | Neovim Plugins

### DIFF
--- a/nvim/lua/plugins/coding/copilot.lua
+++ b/nvim/lua/plugins/coding/copilot.lua
@@ -1,1 +1,1 @@
-return { "github/copilot.vim" }
+return { "github/copilot.vim", enabled = false }

--- a/nvim/lua/plugins/coding/nvim-lspconfig.lua
+++ b/nvim/lua/plugins/coding/nvim-lspconfig.lua
@@ -5,6 +5,8 @@ return {
 		vim.lsp.enable("dockerls")
 		vim.lsp.enable("docker_compose_language_service")
 		vim.lsp.enable("eslint")
+		vim.lsp.enable("gopls")
+		vim.lsp.enable("graphql-language-service")
 		vim.lsp.enable("html")
 		vim.lsp.enable("jsonls")
 		vim.lsp.enable("lua_ls")
@@ -14,7 +16,9 @@ return {
 		vim.lsp.enable("ruff")
 		vim.lsp.enable("rust_analyzer")
 		vim.lsp.enable("sql-language-server")
+		vim.lsp.enable("svelte")
+		vim.lsp.enable("tailwindcss")
 		vim.lsp.enable("taplo")
-		vim.lsp.enable("tsserver")
+		vim.lsp.enable("ts_ls")
 	end,
 }

--- a/nvim/lua/plugins/coding/nvim-treesitter.lua
+++ b/nvim/lua/plugins/coding/nvim-treesitter.lua
@@ -1,13 +1,25 @@
 return {
 	"nvim-treesitter/nvim-treesitter",
 	build = ":TSUpdate",
+	config = function()
+		require("nvim-treesitter.configs").setup({
+			highlight = {
+				enable = true,
+				-- Setting this to true will run `:h syntax` and tree-sitter at the same time.
+				-- Set this to `true` if you depend on 'syntax' being enabled (like for indentation).
+				-- Using this option may slow down your editor, and you may see some duplicate highlights.
+				-- Instead of true it can also be a list of languages
+				additional_vim_regex_highlighting = false,
+			},
+		})
+	end,
 	dependencies = {
 		-- `nvim-treesitter-context` - Lightweight alternative to `context.vim`.
 		"nvim-treesitter/nvim-treesitter-context",
 		-- `nvim-treesitter-textobjects` - Syntax aware text-objects, select,
 		-- move, swap, and peek support.
-		"nvim-treesitter/nvim-treesitter-textobjects"
+		"nvim-treesitter/nvim-treesitter-textobjects",
 	},
 	lazy = false,
-	priority = 10000
+	priority = 10000,
 }

--- a/nvim/lua/plugins/formatting/conform.lua
+++ b/nvim/lua/plugins/formatting/conform.lua
@@ -3,25 +3,36 @@ return {
 	"stevearc/conform.nvim",
 	opts = {
 		formatters = {
-			injected = { options = { ignore_errors = true } },
 			sqlfluff = {
 				command = "sqlfluff",
 				args = { "format", "--dialect", "sqlite", "--disable-progress-bar", "-n", "-" },
 			},
 		},
 		formatters_by_ft = {
-			-- enables formatting of embedded code blocks
-			["*"] = { "injected" },
+			css = { "prettier", stop_after_first = true },
+			go = { "gofmt" },
+			graphql = { "prettier", stop_after_first = true },
+			html = { "prettier", stop_after_first = true },
+			javascript = { "prettier", stop_after_first = true },
+			json = { "prettier", stop_after_first = true },
+			jsonc = { "prettier", stop_after_first = true },
 			lua = { "stylua" },
 			markdown = { "mdformat" },
-			python = { "isort", "black" },
+			python = { "ruff_format", "isort" },
 			rust = { "rustfmt", lsp_format = "fallback" },
 			sql = { "sqlfluff" },
-			javascript = { "prettierd", "prettier", stop_after_first = true },
+			svelte = { "prettier-plugin-svelte" },
+			typescript = { "prettier", stop_after_first = true },
+			-- Use the "_" filetype to run formatters on filetypes that don't
+			-- have other formatters configured.
+			["_"] = { "trim_whitespace" },
 		},
 		format_on_save = {
 			timeout_ms = 500,
 			lsp_format = "fallback",
 		},
+		log_level = vim.log.levels.DEBUG,
+		notify_on_error = true,
+		notify_no_formatters = true,
 	},
 }


### PR DESCRIPTION
# Description

This PR updates the following plugins:

- `copilot` - Disabled by default.
- `nvim-lspconfig` - Added more language support.
- `nvim-treesitter` - Added additional highlight support.
- `conform` - Added more language support.