### PR TITLE
Update | Telescope.nvim keybinding override for LSP references

### DIFF
--- a/nvim/lua/plugins/ui/telescope.lua
+++ b/nvim/lua/plugins/ui/telescope.lua
@@ -50,6 +50,9 @@ return {
 		vim.keymap.set("n", "<leader>fb", builtin.buffers, {})
 		vim.keymap.set("n", "<leader>fh", builtin.help_tags, {})
 
+		-- LSP references override.
+		vim.keymap.set("n", "gr", builtin.lsp_references, {})
+
 		-- Git pickers.
 		vim.keymap.set("n", "<leader>gf", builtin.git_files, {})
 		vim.keymap.set("n", "<leader>gc", builtin.git_commits, {})


### PR DESCRIPTION
# Description

This PR updates the plugin file for Telscope.nvim to use Telescope for LSP references instead of the default view.